### PR TITLE
Bump Version to go1.12.1 in Godep

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -1,6 +1,6 @@
 {
 	"ImportPath": "github.com/EngineerBetter/cf-mysql-example-app",
-	"GoVersion": "go1.8",
+	"GoVersion": "go1.12.1",
 	"GodepVersion": "v75",
 	"Deps": [
 		{


### PR DESCRIPTION
With PCF Go Buildpack version 1.8.36 removing support for 1.8.x, app staging was failing. 
While a few changes must be done (such as removing Godeps/_workspace), simply bumping up the verion will do the trick for now!!